### PR TITLE
Specific exception when not inside a git repository

### DIFF
--- a/source/Appccelerate.VersionCore/RepositoryVersionInformationLoader.cs
+++ b/source/Appccelerate.VersionCore/RepositoryVersionInformationLoader.cs
@@ -30,6 +30,11 @@ namespace Appccelerate.Version
         {
             string repositoryPath = Repository.Discover(startingPath);
 
+            if (string.IsNullOrEmpty(repositoryPath))
+            {
+                throw new InvalidOperationException("The path is not part of a git repository: " + startingPath);
+            }
+
             var repository = new Repository(repositoryPath);
 
             return this.GetRepositoryVersionInformation(repository);


### PR DESCRIPTION
An InvalidOperationException is thrown when the startingPath is not inside a git repository
