### PR TITLE
Added possibility to specify dedicated file version in tag name 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ Backup*/
 UpgradeLog*.XML
 
 Specs
+/source/.vs

--- a/source/Appccelerate.Version.Facts/Appccelerate.Version.Facts.csproj
+++ b/source/Appccelerate.Version.Facts/Appccelerate.Version.Facts.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\GlobalAssemblyInfo.cs" />
+    <Compile Include="VersionTagParserFacts.cs" />
     <Compile Include="VersionCalculatorFacts.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/source/Appccelerate.Version.Facts/VersionCalculatorFacts.cs
+++ b/source/Appccelerate.Version.Facts/VersionCalculatorFacts.cs
@@ -40,53 +40,69 @@ namespace Appccelerate.Version.Facts
         [InlineData("1.0.0")]
         public void AddsMissingVersionPartsAsZeros(string versionPattern)
         {
-            VersionInformation result = this.testee.CalculateVersion(versionPattern, null, 0, null);
+            VersionInformation result = this.testee.CalculateVersion(versionPattern, "2.0.0.0", null, 0, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.0.0.0"), "1.0.0", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.0.0.0"), new Version("2.0.0.0"), "1.0.0", string.Empty));
         }
 
         [Theory]
-        [InlineData("1.{0}", 0, "1.0.0.0", "1.0.0")]
-        [InlineData("1.2.{0}", 0, "1.2.0.0", "1.2.0")]
-        [InlineData("1.{2}.3", 0, "1.2.3.0", "1.2.3")]
-        [InlineData("1.{2}", 5, "1.7.0.0", "1.7.0")]
-        public void ReplacesPlaceholderWithNumberOfCommitsSinceVersionTaggedCommit(string versionPatterm, int commitsSinceVersionTaggedCommit, string expectedVersion, string expectedNugetVersion)
+        [InlineData("1.{0}", "3.{0}", 0, "1.0.0.0", "3.0.0.0", "1.0.0")]
+        [InlineData("1.2.{0}", "4.5.{0}", 0, "1.2.0.0", "4.5.0.0", "1.2.0")]
+        [InlineData("1.{2}.3", "4.{5}.6", 0, "1.2.3.0", "4.5.6.0", "1.2.3")]
+        [InlineData("1.{2}", "4.{5}", 5, "1.7.0.0", "4.10.0.0", "1.7.0")]
+        public void ReplacesPlaceholderWithNumberOfCommitsSinceVersionTaggedCommit(
+            string versionPattern, 
+            string fileVersionPattern,
+            int commitsSinceVersionTaggedCommit, 
+            string expectedVersion, 
+            string expectedFileVersion, 
+            string expectedNugetVersion)
         {
-            VersionInformation result = this.testee.CalculateVersion(versionPatterm, null, commitsSinceVersionTaggedCommit, null);
+            VersionInformation result = this.testee.CalculateVersion(versionPattern, fileVersionPattern, null, commitsSinceVersionTaggedCommit, null);
 
-            result.Should().Be(new VersionInformation(new Version(expectedVersion), expectedNugetVersion, string.Empty));
+            result.Should().Be(new VersionInformation(new Version(expectedVersion), new Version(expectedFileVersion), expectedNugetVersion, string.Empty));
         }
+        [Theory]
+        [InlineData("1")]
+        [InlineData("1.0")]
+        [InlineData("1.0.0")]
+        public void AddsMissingFileVersionPartsAsZeros(string fileVersionPattern)
+        {
+            VersionInformation result = this.testee.CalculateVersion("2.0.0.0", fileVersionPattern, null, 0, null);
 
+            result.Should().Be(new VersionInformation(new Version("2.0.0.0"), new Version("1.0.0.0"), "2.0.0", string.Empty));
+        }
+        
         [Fact]
         public void KeepsFormattingOfPlaceholder()
         {
-            VersionInformation result = this.testee.CalculateVersion("1-pre{0002}", null, 125, null);
+            VersionInformation result = this.testee.CalculateVersion("1-pre{0002}", "1.0.{0}.0", null, 125, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.0.0.0"), "1.0.0-pre0127", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.0.0.0"), new Version("1.0.125.0"), "1.0.0-pre0127", string.Empty));
         }
 
         [Fact]
         public void SupportsNugetPreReleaseVersions()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre", null, 0, null);
+            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre", "2.0.0.0", null, 0, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.2.3.0"), "1.2.3-pre", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.2.3.0"), new Version("2.0.0.0"), "1.2.3-pre", string.Empty));
         }
 
         [Fact]
         public void SupportsNugetPreReleaseVersionsWithCommitsCountingInPrereleasePart()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre{2}", null, 3, null);
+            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre{2}", "2.0.{0}.0", null, 3, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.2.3.0"), "1.2.3-pre5", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.2.3.0"), new Version("2.0.3.0"), "1.2.3-pre5", string.Empty));
         }
 
         [Fact]
         public void SupportsNugetPreReleaseVersionsWithCommitsCountingInVersionPart()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", null, 3, null);
+            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", "2.0.{0}.0", null, 3, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), "1.5.3-pre", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), new Version("2.0.3.0"), "1.5.3-pre", string.Empty));
         }
 
         [Theory]
@@ -94,41 +110,41 @@ namespace Appccelerate.Version.Facts
         [InlineData("1.2-pre#comment", "1.2.0.0", "1.2.0-pre")]
         public void IgnoresComments(string versionPattern, string expectedVersion, string expectedNugetVersion)
         {
-            VersionInformation result = this.testee.CalculateVersion(versionPattern, null, 0, null);
+            VersionInformation result = this.testee.CalculateVersion(versionPattern, "2.0.0.0", null, 0, null);
 
-            result.Should().Be(new VersionInformation(new Version(expectedVersion), expectedNugetVersion, string.Empty));
+            result.Should().Be(new VersionInformation(new Version(expectedVersion), new Version("2.0.0.0"), expectedNugetVersion, string.Empty));
         }
 
         [Fact]
         public void ReplacesVersionPlaceholderInInformationalVersion()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", "RC 1 {version}", 3, null);
+            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", "2.0.{0}.0", "RC 1 {version}", 3, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), "1.5.3-pre", "RC 1 1.5.3.0"));
+            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), new Version("2.0.3.0"),  "1.5.3-pre", "RC 1 1.5.3.0"));
         }
 
         [Fact]
         public void ReplacesNugetVersionPlaceholderInInformationalVersion()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", "RC 1 {nugetVersion}", 3, null);
+            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", "2.0.{0}.0", "RC 1 {nugetVersion}", 3, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), "1.5.3-pre", "RC 1 1.5.3-pre"));
+            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), new Version("2.0.3.0"), "1.5.3-pre", "RC 1 1.5.3-pre"));
         }
 
         [Fact]
         public void AddsPrereleaseInformation_WhenItIsAPullRequest()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.{2}", null, 0, "override");
+            VersionInformation result = this.testee.CalculateVersion("1.{2}", "2.0.{0}.0", null, 0, "override");
 
-            result.Should().Be(new VersionInformation(new Version("1.2.0.0"), "1.2.0-override", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.2.0.0"), new Version("2.0.0.0"), "1.2.0-override", string.Empty));
         }
 
         [Fact]
         public void ReplacesPrereleaseInformation_WhenItIsAPullRequest()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.{2}-pre", null, 0, "override");
+            VersionInformation result = this.testee.CalculateVersion("1.{2}-pre", "2.0.0.0", null, 0, "override");
 
-            result.Should().Be(new VersionInformation(new Version("1.2.0.0"), "1.2.0-override", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.2.0.0"), new Version("2.0.0.0"), "1.2.0-override", string.Empty));
         }
 
         [Fact]
@@ -136,9 +152,9 @@ namespace Appccelerate.Version.Facts
         {
             const string Version = "1.2.3.0";
 
-            VersionInformation result = this.testee.CalculateVersion(Version, null, 0, null);
+            VersionInformation result = this.testee.CalculateVersion(Version, "2.0.0.0", null, 0, null);
 
-            result.Should().Be(new VersionInformation(new Version(Version), "1.2.3", string.Empty));
+            result.Should().Be(new VersionInformation(new Version(Version), new Version("2.0.0.0"), "1.2.3", string.Empty));
         }
 
         [Fact]
@@ -146,7 +162,7 @@ namespace Appccelerate.Version.Facts
         {
             const string VersionPattern = "1.2.3.0";
 
-            Action action = () => this.testee.CalculateVersion(VersionPattern, null, 1, null);
+            Action action = () => this.testee.CalculateVersion(VersionPattern, "2.0.0.0", null, 1, null);
 
             action.ShouldThrow<InvalidOperationException>()
                 .And.Message.Should().Be(VersionCalculator.FormatCannotVersionDueToMissingCommitsCountingPlaceholderExceptionMessage(VersionPattern));

--- a/source/Appccelerate.Version.Facts/VersionCalculatorFacts.cs
+++ b/source/Appccelerate.Version.Facts/VersionCalculatorFacts.cs
@@ -62,6 +62,7 @@ namespace Appccelerate.Version.Facts
 
             result.Should().Be(new VersionInformation(new Version(expectedVersion), new Version(expectedFileVersion), expectedNugetVersion, string.Empty));
         }
+
         [Theory]
         [InlineData("1")]
         [InlineData("1.0")]

--- a/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
+++ b/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
@@ -18,8 +18,6 @@
 
 namespace Appccelerate.Version.Facts
 {
-    using System;
-
     using FluentAssertions;
 
     using Xunit;

--- a/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
+++ b/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
@@ -21,6 +21,7 @@ namespace Appccelerate.Version.Facts
     using FluentAssertions;
 
     using Xunit;
+    using Xunit.Extensions;
 
     public class VersionTagParserFacts
     {
@@ -30,17 +31,18 @@ namespace Appccelerate.Version.Facts
         {
             this.testee = new VersionTagParser();
         }
-
-        [Fact]
-        public void ReturnsParsedVersionTag()
+        
+        [Theory]
+        [InlineData("4.{2}-alpha001", "4.{2}.0")]
+        [InlineData("11.{13}.0.0", "11.{0}.0")]
+        [InlineData("5.0-alpha{0001}#comment", "5.{0}.0")]
+        public void ReturnsParsedVersionTag(string expectedVersion, string expectedFileVersion)
         {
-            const string ExpectedFileVersion = "fileVersion";
-            const string ExpectedVersion = "version";
-            string versionTag = "v=" + ExpectedVersion + " fv=" + ExpectedFileVersion;
+            string versionTag = "v=" + expectedVersion + " fv=" + expectedFileVersion;
 
             VersionTag result = this.testee.Parse(versionTag);
 
-            result.Should().Be(new VersionTag(ExpectedVersion, ExpectedFileVersion));
+            result.Should().Be(new VersionTag(expectedVersion, expectedFileVersion));
         }
 
         [Fact]

--- a/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
+++ b/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
@@ -1,0 +1,59 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="VersionTagParserFacts.cs" company="Appccelerate">
+//   Copyright (c) 2008-2014
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+namespace Appccelerate.Version.Facts
+{
+    using System;
+
+    using FluentAssertions;
+
+    using Xunit;
+
+    public class VersionTagParserFacts
+    {
+        private readonly VersionTagParser testee;
+
+        public VersionTagParserFacts()
+        {
+            this.testee = new VersionTagParser();
+        }
+
+        [Fact]
+        public void ReturnsParsedVersionTag()
+        {
+            const string ExpectedFileVersion = "fileVersion";
+            const string ExpectedVersion = "version";
+            string versionTag = "v=" + ExpectedVersion + " fv=" + ExpectedFileVersion;
+
+            VersionTag result = this.testee.Parse(versionTag);
+
+            result.Should().Be(new VersionTag(ExpectedVersion, ExpectedFileVersion));
+        }
+
+        [Fact]
+        public void SetFileVersionToVersionWhenTagContainsNoFileVersion()
+        {
+            const string ExpectedVersion = "version";
+            string versionTag = "v=" + ExpectedVersion;
+
+            VersionTag result = this.testee.Parse(versionTag);
+
+            result.Should().Be(new VersionTag(ExpectedVersion, ExpectedVersion));
+        }
+    }
+}

--- a/source/Appccelerate.Version.sln
+++ b/source/Appccelerate.Version.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26730.10
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Appccelerate.VersionExe", "Appccelerate.VersionExe\Appccelerate.VersionExe.csproj", "{2DD20E3E-54EC-482B-98EF-A4EA57F4530C}"
 EndProject
@@ -36,5 +36,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {93926A5D-0F97-4517-A9AA-7DDD3FFC7708}
 	EndGlobalSection
 EndGlobal

--- a/source/Appccelerate.VersionCore/Appccelerate.VersionCore.csproj
+++ b/source/Appccelerate.VersionCore/Appccelerate.VersionCore.csproj
@@ -51,6 +51,8 @@
     <Compile Include="RepositoryVersionInformationLoader.cs" />
     <Compile Include="VersionCalculator.cs" />
     <Compile Include="VersionInformation.cs" />
+    <Compile Include="VersionTag.cs" />
+    <Compile Include="VersionTagParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="NuGet.config" />

--- a/source/Appccelerate.VersionCore/RepositoryVersionInformation.cs
+++ b/source/Appccelerate.VersionCore/RepositoryVersionInformation.cs
@@ -22,18 +22,22 @@ namespace Appccelerate.Version
     {
         public RepositoryVersionInformation(
             string lastTaggedVersion, 
+            string lastTaggedFileVersion, 
             int commitsSinceLastTaggedVersion, 
             string annotationMessage, 
             string prereleaseOverride)
             : this()
         {
             this.LastTaggedVersion = lastTaggedVersion;
+            this.LastTaggedFileVersion = lastTaggedFileVersion;
             this.CommitsSinceLastTaggedVersion = commitsSinceLastTaggedVersion;
             this.AnnotationMessage = annotationMessage;
             this.PrereleaseOverride = prereleaseOverride;
         }
 
         public string LastTaggedVersion { get; private set; }
+
+        public string LastTaggedFileVersion { get; private set; }
 
         public string AnnotationMessage { get; private set; }
 

--- a/source/Appccelerate.VersionCore/RepositoryVersionInformationLoader.cs
+++ b/source/Appccelerate.VersionCore/RepositoryVersionInformationLoader.cs
@@ -26,6 +26,13 @@ namespace Appccelerate.Version
 
     public class RepositoryVersionInformationLoader
     {
+        private readonly VersionTagParser versionTagParser;
+
+        public RepositoryVersionInformationLoader(VersionTagParser versionTagParser)
+        {
+            this.versionTagParser = versionTagParser;
+        }
+
         public RepositoryVersionInformation GetRepositoryVersionInformation(string startingPath)
         {
             string repositoryPath = Repository.Discover(startingPath);
@@ -48,8 +55,11 @@ namespace Appccelerate.Version
             int commits = CountCommitsSinceVersionTag(repository, lastTaggedCommit);
             string prereleaseOverride = DeterminePrereleaseOverride(repository);
 
+            VersionTag versionTag = this.versionTagParser.Parse(latestVersionTag.Name);
+
             return new RepositoryVersionInformation(
-                latestVersionTag.Name.Substring(2),
+                versionTag.Version,
+                versionTag.FileVersion,
                 commits,
                 latestVersionTag.IsAnnotated ? latestVersionTag.Annotation.Message.Replace("\n", string.Empty).Replace("\r", string.Empty) : string.Empty,
                 prereleaseOverride);

--- a/source/Appccelerate.VersionCore/VersionCalculator.cs
+++ b/source/Appccelerate.VersionCore/VersionCalculator.cs
@@ -103,6 +103,7 @@ namespace Appccelerate.Version
             {
                 normalizedVersion += ".0";
             }
+
             return normalizedVersion;
         }
 

--- a/source/Appccelerate.VersionCore/VersionCalculator.cs
+++ b/source/Appccelerate.VersionCore/VersionCalculator.cs
@@ -28,8 +28,9 @@ namespace Appccelerate.Version
 
         public VersionInformation CalculateVersion(
             string versionPattern, 
+            string fileVersionPattern, 
             string informationalVersionPattern, 
-            int commitsSinceLastTaggedVersion,
+            int commitsSinceLastTaggedVersion, 
             string prereleaseVersionOverride)
         {
             informationalVersionPattern = informationalVersionPattern ?? string.Empty;
@@ -37,22 +38,7 @@ namespace Appccelerate.Version
             int commentIndex = versionPattern.IndexOf('#');
             versionPattern = commentIndex > 0 ? versionPattern.Substring(0, commentIndex) : versionPattern;
             
-            Match match = PlaceholderRegex.Match(versionPattern);
-            if (match.Success)
-            {
-                int placeholderLength = match.Value.Length;
-                int baseNumber = int.Parse(match.Value);
-                int calculatedNumber = baseNumber + commitsSinceLastTaggedVersion;
-                string paddedCalculatedNumber = calculatedNumber.ToString(new string('0', placeholderLength));
-                versionPattern = versionPattern.Replace("{" + match.Value + "}", paddedCalculatedNumber);
-            }
-            else
-            {
-                if (commitsSinceLastTaggedVersion > 0)
-                {
-                    throw new InvalidOperationException(FormatCannotVersionDueToMissingCommitsCountingPlaceholderExceptionMessage(versionPattern));
-                }
-            }
+            versionPattern = ReplaceCommitCountPlaceholder(versionPattern, commitsSinceLastTaggedVersion);
 
             int dashIndex = versionPattern.IndexOf('-');
             string prerelease = dashIndex > 0 ? versionPattern.Substring(dashIndex + 1) : string.Empty;
@@ -61,29 +47,63 @@ namespace Appccelerate.Version
 
             string version = dashIndex > 0 ? versionPattern.Substring(0, dashIndex) : versionPattern;
 
-            for (int i = version.Count(c => c == '.'); i < 3; i++)
-            {
-                version += ".0";
-            }
+            string normalizedVersion = NormalizeVersion(version);
+
+            string fileVersion = ReplaceCommitCountPlaceholder(fileVersionPattern, commitsSinceLastTaggedVersion);
+            string normalizedFileVersion = NormalizeVersion(fileVersion);
 
             int j = 0;
-            int thirdDotIndex = version
+            int thirdDotIndex = normalizedVersion
                 .Select(c => new { Index = j++, Char = c })
                 .Where(x => x.Char == '.')
                 .Skip(2)
                 .Select(x => x.Index)
                 .Single();
 
-            string nugetVersion = version.Substring(0, thirdDotIndex) + (prerelease.Any() ? "-" + prerelease : string.Empty);
+            string nugetVersion = normalizedVersion.Substring(0, thirdDotIndex) + (prerelease.Any() ? "-" + prerelease : string.Empty);
 
             string informationalVersion = informationalVersionPattern
-                .Replace("{version}", version)
+                .Replace("{version}", normalizedVersion)
                 .Replace("{nugetVersion}", nugetVersion);
             
             return new VersionInformation(
-                Version.Parse(version),
+                Version.Parse(normalizedVersion),
+                Version.Parse(normalizedFileVersion),
                 nugetVersion,
                 informationalVersion);
+        }
+
+        private static string ReplaceCommitCountPlaceholder(string pattern, int commitsSinceLastTaggedVersion)
+        {
+            Match match = PlaceholderRegex.Match(pattern);
+            if (match.Success)
+            {
+                int placeholderLength = match.Value.Length;
+                int baseNumber = int.Parse(match.Value);
+                int calculatedNumber = baseNumber + commitsSinceLastTaggedVersion;
+                string paddedCalculatedNumber = calculatedNumber.ToString(new string('0', placeholderLength));
+                pattern = pattern.Replace("{" + match.Value + "}", paddedCalculatedNumber);
+            }
+            else
+            {
+                if (commitsSinceLastTaggedVersion > 0)
+                {
+                    throw new InvalidOperationException(
+                        FormatCannotVersionDueToMissingCommitsCountingPlaceholderExceptionMessage(pattern));
+                }
+            }
+
+            return pattern;
+        }
+
+        private static string NormalizeVersion(string version)
+        {
+            string normalizedVersion = version;
+            for (int i = normalizedVersion.Count(c => c == '.'); i < 3; i++)
+            {
+                normalizedVersion += ".0";
+            }
+            return normalizedVersion;
         }
 
         public static string FormatCannotVersionDueToMissingCommitsCountingPlaceholderExceptionMessage(string versionPattern)

--- a/source/Appccelerate.VersionCore/VersionTag.cs
+++ b/source/Appccelerate.VersionCore/VersionTag.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="VersionInformation.cs" company="Appccelerate">
+// <copyright file="VersionTag.cs" company="Appccelerate">
 //   Copyright (c) 2008-2014
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,29 +18,16 @@
 
 namespace Appccelerate.Version
 {
-    using System;
-
-    public struct VersionInformation
+    public struct VersionTag
     {
-        public VersionInformation(
-            Version version, 
-            Version fileVersion, 
-            string nugetVersion, 
-            string informationalVersion)
-            : this()
+        public VersionTag(string version, string fileVersion) : this()
         {
             this.Version = version;
             this.FileVersion = fileVersion;
-            this.InformationalVersion = informationalVersion;
-            this.NugetVersion = nugetVersion;
         }
 
-        public Version Version { get; private set; }
+        public string Version { get; private set; }
 
-        public Version FileVersion { get; private set; }
-
-        public string NugetVersion { get; private set; }
-
-        public string InformationalVersion { get; set; }
+        public string FileVersion { get; private set; }
     }
 }

--- a/source/Appccelerate.VersionCore/VersionTagParser.cs
+++ b/source/Appccelerate.VersionCore/VersionTagParser.cs
@@ -1,5 +1,5 @@
 ﻿// --------------------------------------------------------------------------------------------------------------------
-// <copyright file="VersionInformation.cs" company="Appccelerate">
+// <copyright file="VersionTagParser.cs" company="Appccelerate">
 //   Copyright (c) 2008-2014
 //
 //   Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,29 +18,20 @@
 
 namespace Appccelerate.Version
 {
-    using System;
-
-    public struct VersionInformation
+    public class VersionTagParser
     {
-        public VersionInformation(
-            Version version, 
-            Version fileVersion, 
-            string nugetVersion, 
-            string informationalVersion)
-            : this()
+        public VersionTag Parse(string versionTag)
         {
-            this.Version = version;
-            this.FileVersion = fileVersion;
-            this.InformationalVersion = informationalVersion;
-            this.NugetVersion = nugetVersion;
+            string[] splittedTag = versionTag.Split(' ');
+            
+            string version = splittedTag[0].Substring(2);
+            string fileVersion = version;
+            if (splittedTag.Length > 1)
+            {
+                fileVersion = splittedTag[1].Substring(3);
+            }
+
+            return new VersionTag(version, fileVersion);
         }
-
-        public Version Version { get; private set; }
-
-        public Version FileVersion { get; private set; }
-
-        public string NugetVersion { get; private set; }
-
-        public string InformationalVersion { get; set; }
     }
 }

--- a/source/Appccelerate.VersionCore/VersionTagParser.cs
+++ b/source/Appccelerate.VersionCore/VersionTagParser.cs
@@ -18,19 +18,22 @@
 
 namespace Appccelerate.Version
 {
+    using System.Text.RegularExpressions;
+
     public class VersionTagParser
     {
+        private static readonly Regex VersionRegex = 
+            new Regex(@"\bv=(?<version>[^ ]*)(\s*fv=(?<fileVersion>[^ ]*))?", RegexOptions.Compiled);
+
         public VersionTag Parse(string versionTag)
         {
-            string[] splittedTag = versionTag.Split(' ');
-            
-            string version = splittedTag[0].Substring(2);
-            string fileVersion = version;
-            if (splittedTag.Length > 1)
-            {
-                fileVersion = splittedTag[1].Substring(3);
-            }
+            Match match = VersionRegex.Match(versionTag);
 
+            string version = match.Groups["version"].Value;
+
+            var matchGroup = match.Groups["fileVersion"];
+            string fileVersion = matchGroup.Success ? matchGroup.Value : version;
+            
             return new VersionTag(version, fileVersion);
         }
     }

--- a/source/Appccelerate.VersionExe/Program.cs
+++ b/source/Appccelerate.VersionExe/Program.cs
@@ -34,7 +34,7 @@ namespace Appccelerate.Version
                     output = args[2];
                 }
 
-                var repositoryVersionInformationLoader = new RepositoryVersionInformationLoader();
+                var repositoryVersionInformationLoader = new RepositoryVersionInformationLoader(new VersionTagParser());
 
                 RepositoryVersionInformation repositoryVersionInformation = repositoryVersionInformationLoader.GetRepositoryVersionInformation(startingPath);
                 
@@ -42,6 +42,7 @@ namespace Appccelerate.Version
 
                 var version = calculator.CalculateVersion(
                     repositoryVersionInformation.LastTaggedVersion,
+                    repositoryVersionInformation.LastTaggedFileVersion,
                     repositoryVersionInformation.AnnotationMessage,
                     repositoryVersionInformation.CommitsSinceLastTaggedVersion,
                     repositoryVersionInformation.PrereleaseOverride);
@@ -50,6 +51,7 @@ namespace Appccelerate.Version
                 {
                     Console.WriteLine("{");
                     Console.WriteLine("\"Version\": \"" + version.Version + "\",");
+                    Console.WriteLine("\"FileVersion\": \"" + version.FileVersion + "\",");
                     Console.WriteLine("\"NugetVersion\": \"" + version.NugetVersion + "\",");
                     Console.WriteLine("\"InformationalVersion\": \"" + version.InformationalVersion + "\"");
                     Console.WriteLine("}");

--- a/source/Appccelerate.VersionTask/VersionTask.cs
+++ b/source/Appccelerate.VersionTask/VersionTask.cs
@@ -69,7 +69,7 @@ namespace Appccelerate.VersionTask
         {
             string startingPath = this.SolutionDirectory;
 
-            var repositoryVersionInformationLoader = new RepositoryVersionInformationLoader();
+            var repositoryVersionInformationLoader = new RepositoryVersionInformationLoader(new VersionTagParser());
 
             RepositoryVersionInformation repositoryVersionInformation =
                 repositoryVersionInformationLoader.GetRepositoryVersionInformation(startingPath);
@@ -82,6 +82,7 @@ namespace Appccelerate.VersionTask
 
             var version = calculator.CalculateVersion(
                 repositoryVersionInformation.LastTaggedVersion,
+                repositoryVersionInformation.LastTaggedFileVersion,
                 repositoryVersionInformation.AnnotationMessage,
                 repositoryVersionInformation.CommitsSinceLastTaggedVersion,
                 repositoryVersionInformation.PrereleaseOverride);
@@ -96,10 +97,11 @@ using System;
 using System.Reflection;
 
 [assembly: AssemblyVersion(""{0}"")]
-[assembly: AssemblyFileVersion(""{0}"")]
-[assembly: AssemblyInformationalVersion(""{1}"")]
+[assembly: AssemblyFileVersion(""{1}"")]
+[assembly: AssemblyInformationalVersion(""{2}"")]
 ", 
-                version.Version, 
+                version.Version,
+                version.FileVersion,
                 version.InformationalVersion);
 
             string tempFolder = Path.Combine(Path.GetTempPath(), "Appccelerate.VersionTask");


### PR DESCRIPTION
File Version can be specified using the following syntax for the tag name v={versionPattern} fv={fileVersionPattern}, e.g. v=1.{0} fv=1.4.{0}. The two parts are split by one space.
Use regex instead of substring.