### PR TITLE
Use semicolon for separating version and fileversion information instead of spaces

### DIFF
--- a/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
+++ b/source/Appccelerate.Version.Facts/VersionTagParserFacts.cs
@@ -38,7 +38,7 @@ namespace Appccelerate.Version.Facts
         [InlineData("5.0-alpha{0001}#comment", "5.{0}.0")]
         public void ReturnsParsedVersionTag(string expectedVersion, string expectedFileVersion)
         {
-            string versionTag = "v=" + expectedVersion + " fv=" + expectedFileVersion;
+            string versionTag = $"v={expectedVersion};fv={expectedFileVersion}";
 
             VersionTag result = this.testee.Parse(versionTag);
 
@@ -49,7 +49,7 @@ namespace Appccelerate.Version.Facts
         public void SetFileVersionToVersionWhenTagContainsNoFileVersion()
         {
             const string ExpectedVersion = "version";
-            string versionTag = "v=" + ExpectedVersion;
+            string versionTag = $"v={ExpectedVersion}";
 
             VersionTag result = this.testee.Parse(versionTag);
 

--- a/source/Appccelerate.VersionCore/VersionTagParser.cs
+++ b/source/Appccelerate.VersionCore/VersionTagParser.cs
@@ -23,7 +23,7 @@ namespace Appccelerate.Version
     public class VersionTagParser
     {
         private static readonly Regex VersionRegex = 
-            new Regex(@"\bv=(?<version>[^ ]*)(\s*fv=(?<fileVersion>[^ ]*))?", RegexOptions.Compiled);
+            new Regex(@"\bv=(?<version>[^;]*)(;fv=(?<fileVersion>[^ ]*))?", RegexOptions.Compiled);
 
         public VersionTag Parse(string versionTag)
         {


### PR DESCRIPTION
Git-tags must not contain spaces