### PR TITLE
Quickfix for file version containing prelease notation.

### DIFF
--- a/source/Appccelerate.Version.Facts/VersionCalculatorFacts.cs
+++ b/source/Appccelerate.Version.Facts/VersionCalculatorFacts.cs
@@ -85,7 +85,7 @@ namespace Appccelerate.Version.Facts
         [Fact]
         public void SupportsNugetPreReleaseVersions()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre", "2.0.0.0", null, 0, null);
+            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre", "2.0.0-pre", null, 0, null);
 
             result.Should().Be(new VersionInformation(new Version("1.2.3.0"), new Version("2.0.0.0"), "1.2.3-pre", string.Empty));
         }
@@ -93,17 +93,17 @@ namespace Appccelerate.Version.Facts
         [Fact]
         public void SupportsNugetPreReleaseVersionsWithCommitsCountingInPrereleasePart()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre{2}", "2.0.{0}.0", null, 3, null);
+            VersionInformation result = this.testee.CalculateVersion("1.2.3-pre{2}", "2.0-pre{0}", null, 3, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.2.3.0"), new Version("2.0.3.0"), "1.2.3-pre5", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.2.3.0"), new Version("2.0.0.0"), "1.2.3-pre5", string.Empty));
         }
 
         [Fact]
         public void SupportsNugetPreReleaseVersionsWithCommitsCountingInVersionPart()
         {
-            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", "2.0.{0}.0", null, 3, null);
+            VersionInformation result = this.testee.CalculateVersion("1.{2}.3-pre", "2.{0}-pre", null, 3, null);
 
-            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), new Version("2.0.3.0"), "1.5.3-pre", string.Empty));
+            result.Should().Be(new VersionInformation(new Version("1.5.3.0"), new Version("2.3.0.0"), "1.5.3-pre", string.Empty));
         }
 
         [Theory]

--- a/source/Appccelerate.VersionCore/VersionCalculator.cs
+++ b/source/Appccelerate.VersionCore/VersionCalculator.cs
@@ -49,7 +49,10 @@ namespace Appccelerate.Version
 
             string normalizedVersion = NormalizeVersion(version);
 
-            string fileVersion = ReplaceCommitCountPlaceholder(fileVersionPattern, commitsSinceLastTaggedVersion);
+            fileVersionPattern = ReplaceCommitCountPlaceholder(fileVersionPattern, commitsSinceLastTaggedVersion);
+            int fileVersionDashIndex = fileVersionPattern.IndexOf('-');
+
+            string fileVersion = fileVersionDashIndex > 0 ? fileVersionPattern.Substring(0, fileVersionDashIndex) : fileVersionPattern;
             string normalizedFileVersion = NormalizeVersion(fileVersion);
 
             int j = 0;


### PR DESCRIPTION
Fixes the following bug:
Since the assembly file version defaults to the version information in case of a missing file version pattern,
tags like "v=1.2-pre{000}" led to version parsing exceptions.

The implemented quickfix ensures that the behavior for the file version is the same as for the version.
